### PR TITLE
Changed metric names now show up in both Overview and Database tabs. Ess...

### DIFF
--- a/lib/newrelic_riak/riak_client.rb
+++ b/lib/newrelic_riak/riak_client.rb
@@ -37,7 +37,7 @@ DependencyDetection.defer do
 
         robject = args[0].is_a?(Array) ? args[0][0] : args[0]
         bucket = robject.respond_to?(:bucket) && robject.bucket ? robject.bucket.name : ''
-        bucket = self.newrelic_riak_constantize(bucket)
+        bucket = self.newrelic_riak_camelize(bucket)
         metrics = ["ActiveRecord/#{bucket}/save", total_metric, 'ActiveRecord/#{bucket}', 'ActiveRecord/save', 'ActiveRecord/all']
 
         self.class.trace_execution_scoped(metrics) do
@@ -61,7 +61,7 @@ DependencyDetection.defer do
 
         bucket = args[0].is_a?(Array) ? args[0][0] : args[0]
         bucket = bucket && bucket.respond_to?(:name) ? bucket.name : bucket.to_s
-        bucket = self.newrelic_riak_constantize(bucket)
+        bucket = self.newrelic_riak_camelize(bucket)
         metrics = ["ActiveRecord/#{bucket}/find", total_metric, 'ActiveRecord/#{bucket}', 'ActiveRecord/find', 'ActiveRecord/all']
 
         self.class.trace_execution_scoped(metrics) do
@@ -81,9 +81,10 @@ DependencyDetection.defer do
       alias_method :get_object_without_newrelic_trace, :get_object
       alias_method :get_object, :get_object_with_newrelic_trace
 
-      def newrelic_riak_constantize(term)
+      # turn bucket-name-for-things_that_ar-ok into BucketNameForThingsThatArOk
+      def newrelic_riak_camelize(term)
         string = term.to_s.capitalize
-        string.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{$2.capitalize}" }
+        string.gsub(/[_-]([a-z]*)/) { "#{$1.capitalize}" }
       end
     end
 


### PR DESCRIPTION
...entially impersonating ActiveRecord.

I opened a case with NewRelic, their ruby guy informed us the only way to get metrics into the Overview and Database tabs is to impersonate ActiveRecord, so we should duplicate whats done in the newrelic gem around ActiveRecord.

Not entirely sure if the constantize method is the way to go, or if we even need it. Only included it because if it works I'll do a PR to the original alinpopa gem and I figure the general populace would want it. Open for suggestions on better ways of implementing that method btw.

@betamatt @wjossey @amdtech
