### PR TITLE
Instrumenting the riak protobuffs 2i method

### DIFF
--- a/lib/newrelic_riak/riak_client.rb
+++ b/lib/newrelic_riak/riak_client.rb
@@ -93,6 +93,7 @@ DependencyDetection.defer do
       add_method_tracer :server_info, 'Database/Riak/server_info'
       add_method_tracer :get_client_id, 'Database/Riak/get_client_id'
       add_method_tracer :set_client_id, 'Database/Riak/set_client_id'
+      add_method_tracer :get_index, 'Database/Riak/get_index'
     end
     ::Riak::Client::HTTPBackend.class_eval &backend_tracers
     ::Riak::Client::HTTPBackend.class_eval do


### PR DESCRIPTION
ping @wjossey @marcuswalser @geoffreyclark @ydderd @jfeng 

So, we're not instrumenting 2i when using PBuffs. This obscured a problem in new relic, making it look like "ruby time" was the problem, but it was really Riak time that was the problem.