### PR TITLE
Bump newrelic version

### DIFF
--- a/lib/newrelic_riak/riak_client.rb
+++ b/lib/newrelic_riak/riak_client.rb
@@ -29,7 +29,7 @@ DependencyDetection.defer do
     ::Riak::Client.class_eval do
 
       def store_object_with_newrelic_trace(*args, &blk)
-        if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
+        if NewRelic::Agent::Transaction.recording_web_transaction?
           total_metric = 'ActiveRecord/allWeb'
         else
           total_metric = 'ActiveRecord/allOther'
@@ -53,7 +53,7 @@ DependencyDetection.defer do
       end
 
       def get_object_with_newrelic_trace(*args, &blk)
-        if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
+        if NewRelic::Agent::Transaction.recording_web_transaction?
           total_metric = 'ActiveRecord/allWeb'
         else
           total_metric = 'ActiveRecord/allOther'

--- a/newrelic_riak.gemspec
+++ b/newrelic_riak.gemspec
@@ -1,15 +1,15 @@
 Gem::Specification.new do |gem|
   gem.name = "newrelic_riak"
-  gem.version = "0.1.1.1"
+  gem.version = "0.1.1.2"
   gem.authors = ["Alin Popa"]
   gem.date = "2012-04-23"
   gem.description = "Tapjoy Fork of the NewRelic instrumentation for Riak."
   gem.email = ["alin.popa@gmail.com"]
   gem.homepage = "https://github.com/alinpopa/newrelic-riak"
   gem.summary = "NewRelic instrumentation for Riak."
-  
-  gem.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.0"])
-  
+
+  gem.add_runtime_dependency(%q<newrelic_rpm>, ["~> 4.5"])
+
   gem.files = ["README.md", "lib/newrelic_riak.rb", "lib/newrelic_riak/riak_client.rb", "lib/newrelic_riak/ripple.rb", "newrelic_riak.gemspec"]
   gem.require_paths = ['lib']
 end


### PR DESCRIPTION
Don't think this will do!

We have an open PR (https://github.com/Tapjoy/newrelic-riak/pull/4) that bumps us to version `0.2.0` which I believe is the source of the gem in gemfury. 

This will have to wait until we merge that in, since that might be the one we're using in prod

@alanbrent 